### PR TITLE
Update flow-binding.yaml

### DIFF
--- a/simulation-to-log-with-filter-predicate/flow-binding.yaml
+++ b/simulation-to-log-with-filter-predicate/flow-binding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: simulation-to-log-with-predicate-filter
 spec:
   integration:
-    configuration:
-      - type: property
-        value: "quarkus.arc.remove-unused-beans=none"
+    traits:
+      builder:
+        configuration:
+          properties:
+#          - "quarkus.arc.remove-unused-beans=none"
+          - "quarkus.arc.unremovable-types=com.fasterxml.jackson.databind.ObjectMapper"
   source:
     ref:
       kind: Kamelet
@@ -25,7 +28,7 @@ spec:
       apiVersion: camel.apache.org/v1alpha1
       name: predicate-filter-action
     properties:
-      expression: "@.foo =~ /.*Lennon/"
+      expression: "@.foo =~ /.*John/"
   sink:
     ref:
       kind: Kamelet


### PR DESCRIPTION
We should use a build-time property in order the Quarkus build to take it into account. I've tested with 1.5.0 and identified the class that should not be removed, though we can leave it with the wider scope (commented) in case we want to demonstrate a more general way of solving it.